### PR TITLE
ci: Rename junit reports dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,7 +35,7 @@ lib-cov
 coverage
 
 # JUnit reports directory
-test-reports
+junitreports
 
 # nyc test coverage
 .nyc_output

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
   },
   "jest-junit": {
     "suiteName": "Generated unit tests",
-    "outputDirectory": "./test-reports/",
+    "outputDirectory": "./junitreports/",
     "outputName": "junit.xml",
     "uniqueOutputName": "false",
     "classNameTemplate": "{classname}",


### PR DESCRIPTION


## PR summary

Rename junit reports dir to match other sdks

## PR Checklist

Please make sure that your PR fulfills the following requirements:

- [x] The commit message follows the
[Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type  
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [x] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?
junit reports saved in `test-reports` dir

## What is the new behavior?
junit reports saved in `junitreports` dir

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No