### PR TITLE
Add round up to expire and refresh time difference check.

### DIFF
--- a/test/unit/sessionTokenManager.test.js
+++ b/test/unit/sessionTokenManager.test.js
@@ -159,7 +159,10 @@ describe('SessionTokenManager tests', () => {
       assert.strictEqual(Math.ceil(manager.expireTime - dateNow / 1000), 10);
       assert.strictEqual(Math.ceil(manager.refreshTime - dateNow / 1000), 8);
       /* time difference between expire time and refresh time should be 2 seconds */
-      assert.strictEqual(manager.expireTime - manager.refreshTime, 2);
+      assert.strictEqual(
+        Math.ceil(manager.expireTime - manager.refreshTime),
+        2
+      );
       assert.strictEqual(manager.accessToken, '123456');
     });
 


### PR DESCRIPTION
## PR summary

<!-- please include a brief summary of the changes in this PR -->

Fixes: #19 

**Note: An existing issue is [required](https://github.com/IBM/cloudant-node-sdk/blob/master/CONTRIBUTING.md#PRs) before opening a PR.**

## PR Checklist

Please make sure that your PR fulfills the following requirements:

- [ ] The commit message follows the
[Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->
Intermittently the unit test fails with the following error:
```
FAIL  test/unit/sessionTokenManager.test.js
262  ● SessionTokenManager tests › Test saveTokenInfo › Session token with expire time stamp
263
264    assert.strictEqual(received, expected)
265
266    Expected value to strictly be equal to:
267      2
268    Received:
269      1.7999999523162842
270
271      160 |       assert.strictEqual(Math.ceil(manager.refreshTime - dateNow / 1000), 8);
272      161 |       /* time difference between expire time and refresh time should be 2 seconds */
273    > 162 |       assert.strictEqual(manager.expireTime - manager.refreshTime, 2);
274          |              ^
275      163 |       assert.strictEqual(manager.accessToken, '123456');
276      164 |     });
277      165 | 
278
279      at Object.<anonymous> (test/unit/sessionTokenManager.test.js:162:14)
```
CI source: https://travis-ci.com/github/IBM/cloudant-node-sdk/jobs/512308385

## What is the new behavior?
<!-- Please describe the new behavior after your change. -->
The time difference between  expire and refresh time is not always exactly 2 seconds, this change rounds up the seconds if the difference is less than 2 seconds.

There were 2 issues that was caught, so probably this correction will be enough to stabilise the unit test.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and
migration path for existing applications below. -->

## Other information

<!-- Please add any additional information that would help reviewers evaluate
your PR-->
