### PR TITLE
209 session renewal

### DIFF
--- a/auth/sessionTokenManager.ts
+++ b/auth/sessionTokenManager.ts
@@ -1,5 +1,5 @@
 /**
- * © Copyright IBM Corporation 2020. All Rights Reserved.
+ * © Copyright IBM Corporation 2020, 2021. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -118,7 +118,7 @@ export class SessionTokenManager extends TokenManager {
    */
   protected saveTokenInfo(tokenResponse): void {
     const sessionCookie = tokenResponse.headers['set-cookie'];
-    if (!(sessionCookie instanceof Array)) {
+    if (!Array.isArray(sessionCookie)) {
       const err = 'Set-Cookie header not present in response';
       throw new Error(err);
     }

--- a/test/unit/couchdbSessionAuthenticator.test.js
+++ b/test/unit/couchdbSessionAuthenticator.test.js
@@ -1,5 +1,5 @@
 /**
- * © Copyright IBM Corporation 2020. All Rights Reserved.
+ * © Copyright IBM Corporation 2020, 2021. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ const sinon = require('sinon');
 const { CookieJar } = require('tough-cookie');
 const { CouchdbSessionAuthenticator } = require('../../index.ts');
 const { SessionTokenManager } = require('../../auth/sessionTokenManager.ts');
+const { promisify } = require('util');
 
 describe('CouchdbSessionAutheticator tests', () => {
   it('Constructor input validation check', () => {
@@ -50,5 +51,155 @@ describe('CouchdbSessionAutheticator tests', () => {
 
     /* authenticator stores the same jar */
     assert.ok(auth.tokenManager.options.jar, options.jar);
+  });
+
+  // A function that asserts cookie jar values are correct after the specified times
+  // Part 1. Performs authenticate(), sets cookie into jar and retrieves it for assertions
+  // Elapses time (relative to start of test) to the number of seconds specified by the first arg
+  // Part 2. Performs authenticate(), sets cookie into jar and retrieves it for update assertions
+  // Elapses time (relative to start of test) to the number of seconds specified by the second arg
+  // Part 3. Asserts cookie is the one from the second authenticate (i.e. it was refreshed and was not purged by expiry)
+  function renewalTest(useMaxAge, firstElapsedSeconds, secondElapsedSeconds) {
+    const options = {
+      username: 'username',
+      password: 'password',
+      serviceUrl: 'http://cloudant.example:80',
+      jar: new CookieJar(),
+    };
+    // Promisify the cookie jar methods for easier chaining in the test
+    const setCookie = promisify(options.jar.setCookie.bind(options.jar));
+    const getCookie = promisify(options.jar.getCookieString.bind(options.jar));
+    setCookie.bind(options.jar);
+    getCookie.bind(options.jar);
+
+    // Setup of test header responses
+    const makeCookieHeader = (token, elapasedTime) => {
+      return `AuthSession=${token}; Expires=${new Date(
+        Date.now() + 1000 * (elapasedTime + 3600)
+      )} ${useMaxAge ? '; Max-Age=3600' : ''}`;
+    };
+    const headers = [
+      makeCookieHeader('01234', 0),
+      makeCookieHeader('56789', firstElapsedSeconds),
+    ];
+    const auth = new CouchdbSessionAuthenticator(options);
+    auth.configure({});
+
+    const fakeTokenRequest = (index) => {
+      return sinon.fake.resolves({
+        'headers': {
+          'set-cookie': [headers[index]],
+        },
+      });
+    };
+
+    // Fake requestToken for part 1 token request
+    let requestFake = sinon.replace(
+      auth.tokenManager,
+      'requestToken',
+      fakeTokenRequest(0)
+    );
+    let clock;
+    return (
+      /* Start of part 1 */
+      auth
+        .authenticate()
+        .then(() => {
+          assert.ok(
+            requestFake.calledOnce,
+            'There should be exactly 1 session request in part 1.'
+          );
+          return setCookie(headers[0], options.serviceUrl, {});
+        })
+        .then(() => {
+          return getCookie(options.serviceUrl);
+        })
+        .then((cookieFromJar) => {
+          assert.strictEqual(cookieFromJar, 'AuthSession=01234');
+        })
+        /* End of part 1*/
+        .then(() => {
+          // Re-fake requestToken for part 2 token request
+          sinon.restore();
+          requestFake = sinon.replace(
+            auth.tokenManager,
+            'requestToken',
+            fakeTokenRequest(1)
+          );
+          // Advance the clock to the first number of elapsed seconds after the initial request
+          clock = sinon.useFakeTimers(Date.now());
+          clock.tick(1000 * firstElapsedSeconds);
+        })
+        /* Start of part 2 */
+        .then(() => {
+          return auth.authenticate();
+        })
+        .then(() => {
+          assert.ok(
+            requestFake.calledOnce,
+            'There should be exactly 1 session request in part 2.'
+          );
+          return setCookie(headers[1], options.serviceUrl, {});
+        })
+        .then(() => {
+          return getCookie(options.serviceUrl);
+        })
+        .then((cookieFromJar) => {
+          assert.strictEqual(
+            cookieFromJar,
+            'AuthSession=56789',
+            'The stored cookie should match that provided by the second session request.'
+          );
+        })
+        /* End of part 2 */
+        .then(() => {
+          // Advance the clock to the second number of elapsed seconds after the initial request
+          // Since we've already advanced to the first number of seconds, we advance by the delta
+          clock.tick(1000 * (secondElapsedSeconds - firstElapsedSeconds));
+        })
+        /* Start of part 3 */
+        .then(() => {
+          return getCookie(options.serviceUrl);
+        })
+        .then((cookieFromJar) => {
+          assert.strictEqual(
+            cookieFromJar,
+            'AuthSession=56789',
+            `The stored cookie should still match that provided by the second session request after the second lapse.`
+          );
+        })
+        /* End of part 3 */
+        .finally(() => {
+          sinon.restore();
+        })
+    );
+  }
+
+  it('Renews pre-emptively correctly (Max-Age)', () => {
+    // Test after an elapsed time of
+    // 2880 seconds (48 minutes i.e. 80% of the 1 hour lifetime)
+    // 3601 seconds (i.e. after the 1 hour lifetime of the original session has passed)
+    return renewalTest(true, 2880, 3601);
+  });
+
+  it('Renews after expiration correctly (Max-Age)', () => {
+    // Test after an elapsed time of
+    // 3601 seconds (i.e. after the 1 hour lifetime has passed)
+    // 7199 seconds (i.e. before the end of the second session)
+    return renewalTest(true, 3601, 7199);
+  });
+
+  it('Renews pre-emptively correctly (Expires)', () => {
+    // Test after an elapsed time of
+    // 2880 seconds (48 minutes i.e. 80% of the 1 hour lifetime)
+    // 3601 seconds (i.e. after the 1 hour lifetime of the original session has passed)
+    return renewalTest(false, 2880, 3601);
+  });
+
+  it('Renews after expiration correctly (Expires)', () => {
+    // Test after an elapsed time of
+    // 3601 seconds (i.e. after the 1 hour lifetime has passed)
+    // 7199 seconds (i.e. before the end of the second session)
+    return renewalTest(false, 3601, 7199);
   });
 });


### PR DESCRIPTION
## PR summary

Fix the issue where, [when using `AUTH_TYPE=COUCHDB_SESSION`](https://github.com/IBM/cloudant-node-sdk#session-cookie-authentication), the renewed session cookies were purged by the third-party cookie store preventing sessions being renewed beyond one lifetime.
<!-- please include a brief summary of the changes in this PR -->

Fixes: #209 
**Note: An existing issue is [required](https://github.com/IBM/cloudant-node-sdk/blob/master/CONTRIBUTING.md#PRs) before opening a PR.**

## PR Checklist

Please make sure that your PR fulfills the following requirements:

- [x] The commit message follows the
[Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features) - N/A current docs are correct.

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

Due to [tough-cookie's interpretation of the cookie spec](https://github.com/salesforce/tough-cookie/issues/154) cookie handling is different to those observed in browsers and most other cases. This means that after a session renewal the new cookie gets purged at the expiry time of the original cookie (i.e. we can't exceed 1 session lifetime).

## What is the new behavior?
<!-- Please describe the new behavior after your change. -->

Monkey patch the supplied (or default created) `CookieJar` to calculate expiry of a cookie with a `Max-Age` header relative to the last time the cookie was updated, not its original creation timestamp.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and
migration path for existing applications below. -->

## Other information

<!-- Please add any additional information that would help reviewers evaluate
your PR-->

Added tests for `Max-Age` and `Expires` style cookies being added/retrieved from jar and renewing preemptively or after expiry. Tests failed without the patch and pass with it.

This patch is intended to restore functionality until resolution of the issue in tough-cookie after which it would be able to be removed or altered to set an option on the supplied jar to enable a tough-cookie provided fix.