### PR TITLE
Check `TAG_NAME` emptiness during doc publish

### DIFF
--- a/scripts/typedoc/publish-doc.sh
+++ b/scripts/typedoc/publish-doc.sh
@@ -23,7 +23,7 @@ printf ">>>>> Finished cloning...\n"
 pushd gh-pages
 
 # Create a new directory for this tag_name and copy the aggregated typedocs there, if it's a tagged release.
-if [ -n "TAG_NAME" ]; then
+if [ -z "TAG_NAME" ]; then
   printf "\n>>>>> Copying aggregated typedocs to new tagged-release directory: %s\n" ${BRANCH_NAME}
   rm -rf docs/${TAG_NAME}
   mkdir -p docs/${TAG_NAME}


### PR DESCRIPTION
## PR summary

<!-- please include a brief summary of the changes in this PR -->

Fixes: -

**Note: An existing issue is [required](https://github.com/IBM/cloudant-node-sdk/blob/master/CONTRIBUTING.md#PRs) before opening a PR.**

## PR Checklist

Please make sure that your PR fulfills the following requirements:

- [ ] The commit message follows the
[Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->
During local `typedoc` publish execution `NEW_SDK_VERSION` variable usually is not defined.
In this case `TAG_NAME` will be an empty string. This causes trouble.

## What is the new behavior?
<!-- Please describe the new behavior after your change. -->
Changed the string check to `-z` that not accept if the string has `''` content.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and
migration path for existing applications below. -->

## Other information

<!-- Please add any additional information that would help reviewers evaluate
your PR-->
