### PR TITLE
build: remove node 17 from engines

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": "^12 || ^14 || ^16 || ^17"
+    "node": "^12 || ^14 || ^16"
   },
   "dependencies": {
     "@types/node": "16.11.6",


### PR DESCRIPTION
## PR summary

Remove Node 17 from list of supported engines.

Follow up from #538 #539

## PR Checklist

Please make sure that your PR fulfills the following requirements:

- [x] The commit message follows the
[Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [x] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

#539 went a little too far in adding this; whilst we test `17` to get ready for `18` it still shouldn't be listed as a supported engine.

## What is the new behavior?
<!-- Please describe the new behavior after your change. -->

As per https://github.com/IBM/cloudant-node-sdk#prerequisites the supported versions of Node are `12`, `14` or `16`.
These are the LTS versions at this time.
This is aligned with the policy outlined at https://nodejs.org/en/about/releases/#releases
>Production applications should only use Active LTS or Maintenance LTS releases.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and
migration path for existing applications below. -->

## Other information

By default this change will not prevent use on Node 17, but it will warn about it - I think that is the correct behaviour based on our support statement, i.e. we're warning you this isn't supported.
In other words the engine listings _do not prevent_ installation of the library on unsupported engines - that is controlled by the consumer's [`engine-strict`config](https://docs.npmjs.com/cli/v7/using-npm/config#engine-strict) setting, the default is to only warn. See also e.g. #563

