### PR TITLE
Change default entry point strategy for typedoc

### DIFF
--- a/scripts/typedoc/generate_typedoc.sh
+++ b/scripts/typedoc/generate_typedoc.sh
@@ -5,5 +5,5 @@
 #    --out ./service-name/v1.ts --target "ES5"
 
 # List the commands for each service here:
-npx typedoc --theme default --excludeExternals --tsconfig tsconfig.json \
-    --out apidocs auth cloudant --includeVersion
+npx typedoc --theme default --entryPointStrategy expand --excludeExternals \
+    --tsconfig tsconfig.json --out apidocs auth cloudant --includeVersion


### PR DESCRIPTION
## PR summary

This change fixes a problem introduced by a breaking change in typedoc 0.22 where default `entryPointStrategy` changed, leading for generated docs to omit `cloudant/v1` module.

## PR Checklist

Please make sure that your PR fulfills the following requirements:

- [x] The commit message follows the
[Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [x] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

Generation of docs for module `cloudant/v1` been omitted

## What is the new behavior?
<!-- Please describe the new behavior after your change. -->

Docs for module `cloudant/v1` properly generated.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and
migration path for existing applications below. -->

## Other information

<!-- Please add any additional information that would help reviewers evaluate
your PR-->
