### PR TITLE
feat: set keepAlive to true by default

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "stubs/.+\\.json|package-lock.json|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2021-12-23T20:01:01Z",
+  "generated_at": "2022-01-21T11:08:54Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -146,7 +146,7 @@
         "hashed_secret": "fc5177639d71196391dd9f4997bc4f240eb29366",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 153,
+        "line_number": 158,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/lib/cloudantBaseService.ts
+++ b/lib/cloudantBaseService.ts
@@ -1,5 +1,5 @@
 /**
- * © Copyright IBM Corporation 2020. All Rights Reserved.
+ * © Copyright IBM Corporation 2020, 2022. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,8 @@ import { Authenticator, BaseService, UserOptions } from 'ibm-cloud-sdk-core';
 import { CookieJar } from 'tough-cookie';
 import { CouchdbSessionAuthenticator } from '../auth';
 import { getSdkHeaders } from './common';
+import { Agent as HttpsAgent } from 'https';
+import { Agent as HttpAgent } from 'http';
 
 /**
  * Set default timeout to 2.5 minutes (= 150000ms)
@@ -102,6 +104,9 @@ export default abstract class CloudantBaseService extends BaseService {
     if (!('timeout' in userOptions)) {
       userOptions.timeout = READ_TIMEOUT;
     }
+
+    CloudantBaseService.setDefaultAgentsIfUnset(userOptions);
+
     super(userOptions);
     this.configureSessionAuthenticator();
   }
@@ -208,5 +213,17 @@ export default abstract class CloudantBaseService extends BaseService {
       }
     }
     return super.createRequest(parameters);
+  }
+
+  private static setDefaultAgentsIfUnset(options: UserOptions) {
+    const cloudantDefaultAgentOptions = {
+      keepAlive: true,
+    };
+    if (!options.httpAgent) {
+      options.httpAgent = new HttpAgent(cloudantDefaultAgentOptions);
+    }
+    if (!options.httpsAgent) {
+      options.httpsAgent = new HttpsAgent(cloudantDefaultAgentOptions);
+    }
   }
 }


### PR DESCRIPTION
## PR summary

`keepAlive` is [not on by default](https://github.com/IBM/node-sdk-core/blob/8b82f36bf6d4ac0163563ce3a10f0a395bd87627/test/unit/request-wrapper.test.js#L130) in `node-sdk-core` which means no connection pooling in `cloudant-node-sdk`.

## PR Checklist

Please make sure that your PR fulfills the following requirements:

- [x] The commit message follows the
[Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?
no connection pooling bu default


## What is the new behavior?
connection pooling bu default with `maxSockets: 6`

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and
migration path for existing applications below. -->

## Other information

<!-- Please add any additional information that would help reviewers evaluate
your PR-->
