### PR TITLE
Combined dependencies PR

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "semantic-release": "19.0.2",
         "sinon": "14.0.0",
         "ts-jest": "27.1.4",
-        "typedoc": "0.22.15",
+        "typedoc": "0.22.16",
         "typescript": "4.6.4"
       },
       "engines": {
@@ -12104,15 +12104,15 @@
       }
     },
     "node_modules/typedoc": {
-      "version": "0.22.15",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.22.15.tgz",
-      "integrity": "sha512-CMd1lrqQbFvbx6S9G6fL4HKp3GoIuhujJReWqlIvSb2T26vGai+8Os3Mde7Pn832pXYemd9BMuuYWhFpL5st0Q==",
+      "version": "0.22.16",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.22.16.tgz",
+      "integrity": "sha512-0Qf0/CsQe6JZTXoYwBM3Iql8gLAWLjQP7O/j9YzfkJp3G/WVGmIMRajKnldJuA/zVvhr+ifsHTgctQh5g2t4iw==",
       "dev": true,
       "dependencies": {
-        "glob": "^7.2.0",
+        "glob": "^8.0.3",
         "lunr": "^2.3.9",
-        "marked": "^4.0.12",
-        "minimatch": "^5.0.1",
+        "marked": "^4.0.16",
+        "minimatch": "^5.1.0",
         "shiki": "^0.10.1"
       },
       "bin": {
@@ -12122,7 +12122,7 @@
         "node": ">= 12.10.0"
       },
       "peerDependencies": {
-        "typescript": "4.0.x || 4.1.x || 4.2.x || 4.3.x || 4.4.x || 4.5.x || 4.6.x"
+        "typescript": "4.0.x || 4.1.x || 4.2.x || 4.3.x || 4.4.x || 4.5.x || 4.6.x || 4.7.x"
       }
     },
     "node_modules/typedoc/node_modules/brace-expansion": {
@@ -12132,6 +12132,25 @@
       "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/typedoc/node_modules/glob": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-8.0.3.tgz",
+      "integrity": "sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^5.0.1",
+        "once": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/typedoc/node_modules/minimatch": {
@@ -21689,15 +21708,15 @@
       }
     },
     "typedoc": {
-      "version": "0.22.15",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.22.15.tgz",
-      "integrity": "sha512-CMd1lrqQbFvbx6S9G6fL4HKp3GoIuhujJReWqlIvSb2T26vGai+8Os3Mde7Pn832pXYemd9BMuuYWhFpL5st0Q==",
+      "version": "0.22.16",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.22.16.tgz",
+      "integrity": "sha512-0Qf0/CsQe6JZTXoYwBM3Iql8gLAWLjQP7O/j9YzfkJp3G/WVGmIMRajKnldJuA/zVvhr+ifsHTgctQh5g2t4iw==",
       "dev": true,
       "requires": {
-        "glob": "^7.2.0",
+        "glob": "^8.0.3",
         "lunr": "^2.3.9",
-        "marked": "^4.0.12",
-        "minimatch": "^5.0.1",
+        "marked": "^4.0.16",
+        "minimatch": "^5.1.0",
         "shiki": "^0.10.1"
       },
       "dependencies": {
@@ -21708,6 +21727,19 @@
           "dev": true,
           "requires": {
             "balanced-match": "^1.0.0"
+          }
+        },
+        "glob": {
+          "version": "8.0.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-8.0.3.tgz",
+          "integrity": "sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^5.0.1",
+            "once": "^1.3.0"
           }
         },
         "minimatch": {

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "semantic-release": "19.0.2",
     "sinon": "14.0.0",
     "ts-jest": "27.1.4",
-    "typedoc": "0.22.15",
+    "typedoc": "0.22.16",
     "typescript": "4.6.4"
   },
   "peerDependencies": {


### PR DESCRIPTION
Combining multiple dependencies PRs into one.

<details>
<summary>Instructions for merging</summary>

* **Use a merge commit**, so that GitHub will mark all original PRs as merged.
* If your repository does not have merge commits enabled, please temporarily enable them in settings. Tick `Allow merge commits` in the repository settings.
* When ready, merge this PR using `Create a merge commit`.

</details>

## Combined PRs

* build(deps-dev): Bump typedoc from 0.22.15 to 0.22.16 (#857) @dependabot
* build(deps-dev): Bump @typescript-eslint/eslint-plugin from 5.26.0 to 5.27.0 (#856) @dependabot
* build(deps-dev): Bump @typescript-eslint/parser from 5.26.0 to 5.27.0 (#855) @dependabot
