### PR TITLE
fix: add missing operation names to path validator

### DIFF
--- a/lib/cloudantBaseService.ts
+++ b/lib/cloudantBaseService.ts
@@ -33,6 +33,9 @@ const READ_TIMEOUT = 150000;
 const DocumentOperations = [
   'deleteDocument',
   'getDocument',
+  'getDocumentAsMixed',
+  'getDocumentAsRelated',
+  'getDocumentAsStream',
   'headDocument',
   'putDocument',
   'deleteAttachment',

--- a/test/integration/cloudant.integration.test.js
+++ b/test/integration/cloudant.integration.test.js
@@ -1,5 +1,5 @@
 /**
- * © Copyright IBM Corporation 2020. All Rights Reserved.
+ * © Copyright IBM Corporation 2020, 2022. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -78,6 +78,21 @@ describe('validate', () => {
   it('get invalid _design document ID', () =>
     cloudant
       .getDocument({
+        db: dbName,
+        docId: '_design',
+      })
+      .then(() => {
+        assert.fail('should not have response');
+      })
+      .catch((err) => {
+        expect(err.message).toBe(
+          'Document ID _design starts with the invalid _ character.'
+        );
+      }));
+
+  it('get invalid _design document ID as stream', () =>
+    cloudant
+      .getDocumentAsStream({
         db: dbName,
         docId: '_design',
       })


### PR DESCRIPTION
## PR summary

add missing operation names to path validator

**Note: An existing issue is [required](https://github.com/IBM/cloudant-java-sdk/blob/main/CONTRIBUTING.md#PRs) before opening a PR.**

## PR Checklist

Please make sure that your PR fulfills the following requirements:

- [x] The commit message follows the
[Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?
Not all operations have paths validated

## What is the new behavior?
Validate paths additionally on

`getDocumentAsMixed`
`getDocumentAsRelated`
`getDocumentAsStream`

## Does this PR introduce a breaking change?

- [x] Yes - _only if previous users relied on previous behaviour_
- [ ] No

migration path: any applications which use special paths for the above operations should use the correct operation, eg one of the `*AllDocs*` methods in the case of the `_all_docs` path.

## Other information

<!-- Please add any additional information that would help reviewers evaluate
your PR-->
