### PR TITLE
chore: remove travis suffix from package targets

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,6 +53,6 @@ jobs:
     - name: Build package
       run: npm run build
     - name: Run tests
-      run: npm run test-travis
+      run: npm run test-ci
     - name: Run lint
       run: npm run lint

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "stubs/.+\\.json|package-lock.json|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2023-06-28T13:33:10Z",
+  "generated_at": "2023-08-14T15:44:25Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -210,7 +210,7 @@
       }
     ]
   },
-  "version": "0.13.1+ibm.60.dss",
+  "version": "0.13.1+ibm.61.dss",
   "word_list": {
     "file": null,
     "hash": null

--- a/package.json
+++ b/package.json
@@ -26,9 +26,9 @@
     "test": "npm run build && npm run lint && jest --runInBand test/",
     "test-unit": "npm run build && jest --runInBand test/unit/",
     "test-integration": "npm run build && jest --runInBand test/integration",
-    "test-travis": "jest --runInBand --testNamePattern='^((?!@slow).)*$' test/",
-    "test-unit-travis": "jest --runInBand test/unit/",
-    "test-integration-travis": "jest --runInBand --no-colors --testNamePattern='^((?!@slow).)*$' --json test/integration > test-output.log"
+    "test-ci": "jest --runInBand --testNamePattern='^((?!@slow).)*$' test/",
+    "test-unit-ci": "jest --runInBand test/unit/",
+    "test-integration-ci": "jest --runInBand --no-colors --testNamePattern='^((?!@slow).)*$' --json test/integration > test-output.log"
   },
   "license": "Apache-2.0",
   "engines": {


### PR DESCRIPTION
## PR summary

Just a tiny cleanup. We haven't used travis for a while and not goign back to it, so not reason to keep it in run's target names.

Fixes: #1207 

**Note: An existing issue is [required](https://github.com/IBM/cloudant-node-sdk/blob/main/CONTRIBUTING.md#PRs) before opening a PR.**

## PR Checklist

Please make sure that your PR fulfills the following requirements:

- [x] The commit message follows the
[Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [x] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

## What is the new behavior?
<!-- Please describe the new behavior after your change. -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and
migration path for existing applications below. -->

## Other information

<!-- Please add any additional information that would help reviewers evaluate
your PR-->
