### PR TITLE
ci: add github action to test docs builder

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,22 @@
+name: docs
+on:
+  pull_request:
+    branches: ['main']
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+      with:
+        persist-credentials: false
+    - name: Setup node 18
+      uses: actions/setup-node@v3
+      with:
+        node-version: '18'
+        check-latest: false
+        cache: 'npm'
+    - name: Install deps
+      run: npm ci --no-audit
+    - name: Build docs
+      run: npm run typedoc

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ test/resources/auth.js
 
 # release folder for typescript-generated source files
 dist/
+apidocs/
 
 ### GitHub recommended ###
 # Logs

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "test-integration": "npm run build && jest --runInBand test/integration",
     "test-ci": "jest --runInBand --testNamePattern='^((?!@slow).)*$' test/",
     "test-unit-ci": "jest --runInBand test/unit/",
-    "test-integration-ci": "jest --runInBand --no-colors --testNamePattern='^((?!@slow).)*$' --json test/integration > test-output.log"
+    "test-integration-ci": "jest --runInBand --no-colors --testNamePattern='^((?!@slow).)*$' --json test/integration > test-output.log",
+    "typedoc": "typedoc --theme default --entryPointStrategy expand --excludeExternals --tsconfig tsconfig.json --out apidocs auth cloudant --includeVersion"
   },
   "license": "Apache-2.0",
   "engines": {


### PR DESCRIPTION
## PR summary

To ensure that we have docs builder working correctly this PR adds a github action that'd run docs build command on pull requests against `main`.

We don't care about difference with `gh-pages` content, so the test is only about ability to successfully run the docs build command itself.

## PR Checklist

Please make sure that your PR fulfills the following requirements:

- [x] The commit message follows the
[Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [x] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

## What is the new behavior?
<!-- Please describe the new behavior after your change. -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and
migration path for existing applications below. -->

## Other information

<!-- Please add any additional information that would help reviewers evaluate
your PR-->
