### PR TITLE
build: remove node 16 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
   test:
     strategy:
       matrix:
-        node: ['16', '18', '20']
+        node: ['18', '20']
     runs-on: ubuntu-latest
     services:
       couchdb:

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.6.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@types/node": "16.18.48",
+        "@types/node": "18.7.14",
         "ibm-cloud-sdk-core": "4.1.0"
       },
       "devDependencies": {
@@ -37,7 +37,7 @@
         "typescript": "5.2.2"
       },
       "engines": {
-        "node": "^16 || ^18"
+        "node": "^18"
       },
       "peerDependencies": {
         "@types/tough-cookie": "^4.0.0",
@@ -1419,9 +1419,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "16.18.48",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.48.tgz",
-      "integrity": "sha512-mlaecDKQ7rIZrYD7iiKNdzFb6e/qD5I9U1rAhq+Fd+DWvYVs+G2kv74UFHmSOlg5+i/vF3XxuR522V4u8BqO+Q=="
+      "version": "18.7.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.14.tgz",
+      "integrity": "sha512-6bbDaETVi8oyIARulOE9qF1/Qdi/23z6emrUh0fNJRUmjznqrixD4MpGDdgOFk5Xb0m2H6Xu42JGdvAxaJR/wA=="
     },
     "node_modules/@types/semver": {
       "version": "7.5.0",
@@ -8652,9 +8652,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "16.18.48",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.48.tgz",
-      "integrity": "sha512-mlaecDKQ7rIZrYD7iiKNdzFb6e/qD5I9U1rAhq+Fd+DWvYVs+G2kv74UFHmSOlg5+i/vF3XxuR522V4u8BqO+Q=="
+      "version": "18.7.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.14.tgz",
+      "integrity": "sha512-6bbDaETVi8oyIARulOE9qF1/Qdi/23z6emrUh0fNJRUmjznqrixD4MpGDdgOFk5Xb0m2H6Xu42JGdvAxaJR/wA=="
     },
     "@types/semver": {
       "version": "7.5.0",

--- a/package.json
+++ b/package.json
@@ -33,10 +33,10 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": "^16 || ^18"
+    "node": "^18"
   },
   "dependencies": {
-    "@types/node": "16.18.48",
+    "@types/node": "18.7.14",
     "ibm-cloud-sdk-core": "4.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## PR summary
Node 16 is EOL on Sept 11 2023. We should remove support of it.

- Remove Node 16 from engines list in package.json
- Remove Node 16 from Github Actions (I have made it not required, but we still need a PR to remove it from the workflow yaml)
- Update `@types/node` dependency to 18.x (as the oldest LTS)

README changes come in another PR.

## PR Checklist

Please make sure that your PR fulfills the following requirements:

- [x] The commit message follows the
[Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [x] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?
Has Node 16 support.

## What is the new behavior?
Has no Node 16 support.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and
migration path for existing applications below. -->

## Other information

<!-- Please add any additional information that would help reviewers evaluate
your PR-->
