### PR TITLE
fix: set errorTolerance to max when initial value is null

### DIFF
--- a/cloudant/features/changesFollower.ts
+++ b/cloudant/features/changesFollower.ts
@@ -121,7 +121,8 @@ export class ChangesFollower {
     if (errorTolerance < 0) {
       throw new Error('Error tolerance duration must not be negative.');
     }
-    if (errorTolerance === undefined) {
+    // loose equality for null and undefined values
+    if (errorTolerance == undefined) {
       this.errorTolerance = Number.MAX_VALUE;
     } else {
       this.errorTolerance = errorTolerance;

--- a/test/unit/features/changesFollower.test.js
+++ b/test/unit/features/changesFollower.test.js
@@ -126,6 +126,29 @@ describe('Test ChangesFollower', () => {
         );
       }).toThrow('Error tolerance duration must not be negative.');
     });
+    it('testInitializationWithNullErrorTolerance', () => {
+      const changesFollower = new ChangesFollower(
+        service,
+        minimumTestParams,
+        null
+      );
+      expect(changesFollower.errorTolerance).toEqual(Number.MAX_VALUE);
+    });
+    it('testInitializationWithUndefinedErrorTolerance', () => {
+      // implicitly set to undefined
+      const changesFollowerImpl = new ChangesFollower(
+        service,
+        minimumTestParams
+      );
+      expect(changesFollowerImpl.errorTolerance).toEqual(Number.MAX_VALUE);
+      // explicitly set to undefined
+      const changesFollowerExpl = new ChangesFollower(
+        service,
+        minimumTestParams,
+        undefined
+      );
+      expect(changesFollowerExpl.errorTolerance).toEqual(Number.MAX_VALUE);
+    });
     it.each(getInvalidTimeoutClients())(
       'testInitializationInvalidTimeoutClients $timeout',
       (client) => {


### PR DESCRIPTION
## PR summary

<!-- please include a brief summary of the changes in this PR -->

Fixes: #1384

**Note: An existing issue is [required](https://github.com/IBM/cloudant-node-sdk/blob/main/CONTRIBUTING.md#PRs) before opening a PR.**

## PR Checklist

Please make sure that your PR fulfills the following requirements:

- [x] The commit message follows the
[Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?
Error tolerance deadline exceeds immediately (as behaves as 0) when `errorTolerance` is set explicitly to `null`.

## What is the new behavior?
Error tolerance is set to max (infinity) when `errorTolerance` is set explicitly to `null`.

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and
migration path for existing applications below. -->
Use `0` instead of `null` to disable error suppression and terminate changes follower on any failed request as it is documented.

## Other information

<!-- Please add any additional information that would help reviewers evaluate
your PR-->
