### PR TITLE
fix(docs): hide typedoc for internal changes follower code

### DIFF
--- a/auth/index.ts
+++ b/auth/index.ts
@@ -22,5 +22,8 @@ export {
   getAuthenticatorFromEnvironment,
 } from 'ibm-cloud-sdk-core';
 
-export { CouchdbSessionAuthenticator } from './couchdbSessionAuthenticator';
+export {
+  CouchdbSessionAuthenticator,
+  CouchdbSessionAuthenticatorOptions,
+} from './couchdbSessionAuthenticator';
 export { SessionTokenManager } from './sessionTokenManager';

--- a/cloudant/features/changesFollower.ts
+++ b/cloudant/features/changesFollower.ts
@@ -21,8 +21,8 @@ import { pipeline, Readable } from 'stream';
 import { ChangesResultIterableIterator } from './changesResultIterator';
 import CloudantV1 = require('../v1');
 
+/** @internal */
 export enum Mode {
-  /** @internal */
   FINITE,
   LISTEN,
 }
@@ -31,18 +31,18 @@ export enum Mode {
  * A helper for using the changes feed.
  *
  * There are two modes of operation:
- *  * {@link #startOneOff()} to fetch the changes from the supplied since sequence
+ *  * {@link startOneOff} to fetch the changes from the supplied since sequence
  *    until there are no further pending changes.
- *  * {@link #start()} to fetch the changes from the supplied since sequence and
+ *  * {@link start} to fetch the changes from the supplied since sequence and
  *    then continuing to listen indefinitely for further new changes.
  *
  * The starting sequence ID can be changed for either mode by using
  * {@link CloudantV1.PostChangesParams.since}. By default when using:
- *  * {@link #startOneOff()} the feed will start from the beginning.
- *  * {@link #start()} the feed will start from "now".
+ *  * {@link startOneOff} the feed will start from the beginning.
+ *  * {@link start} the feed will start from "now".
  *
  * In either mode the {@link Stream} of changes can be terminated early by calling
- * {@link #stop()}.
+ * {@link stop}.
  *
  * By default {@link ChangesFollower} will suppress transient errors indefinitely and
  * endeavour to run to completion or listen forever. For applications where that
@@ -82,6 +82,7 @@ export enum Mode {
  * configuration has sufficiently long timeouts.
  */
 export class ChangesFollower {
+  /** @internal */
   static BATCH_SIZE = 10_000;
 
   // Initialization fields
@@ -93,7 +94,7 @@ export class ChangesFollower {
 
   private limit: number;
 
-  changesResultIterator: ChangesResultIterableIterator;
+  private changesResultIterator: ChangesResultIterableIterator;
 
   /**
    * Create a new {@link ChangesFollower} using the supplied client and params that
@@ -146,13 +147,13 @@ export class ChangesFollower {
    *  * a terminal error (e.g. unauthorized client).
    *  * transient errors occur for longer than the error suppression duration.
    *  * the number of changes received reaches the limit specified in the {@link CloudantV1.PostChangesParams} used to instantiate this {@link ChangesFollower}.
-   *  * {@link ChangesFollower#stop()} is called.
+   *  * {@link stop} is called.
    *
    * The same change may be received more than once.
    *
    * @return {Stream} at least one {@link ChangesResultItem} per change
    * @throws {Error} if:
-   *  * {@link ChangesFollower#start} or {@link ChangesFollower#startOneOff} was already called.
+   *  * {@link start} or {@link startOneOff} was already called.
    *  * a terminal error or unsuppressed transient error is received from the service when fetching changes.
    */
   start(): Stream<ChangesResultItem> {
@@ -167,13 +168,13 @@ export class ChangesFollower {
    *  * a terminal error (e.g. unauthorized client).
    *  * transient errors occur for longer than the error suppression duration.
    *  * the number of changes received reaches the limit specified in the {@link CloudantV1.PostChangesParams} used to instantiate this {@link ChangesFollower}.
-   *  * {@link ChangesFollower#stop} is called.
+   *  * {@link stop} is called.
    *
    * The same change may be received more than once.
    *
    * @return {Stream} at least one {@link ChangesResultItem} per change
    * @throws {Error} if:
-   *  * {@link ChangesFollower#start} or {@link ChangesFollower#startOneOff} was already called.
+   *  * {@link start} or {@link startOneOff} was already called.
    *  * a terminal error or unsuppressed transient error is received from the service when fetching changes.
    */
   startOneOff(): Stream<ChangesResultItem> {
@@ -183,8 +184,8 @@ export class ChangesFollower {
   /**
    * Stop this {@link ChangesFollower}.
    *
-   * @throws {Error} if {@link ChangesFollower#start}
-   * or {@link ChangesFollower#startOneOff} was not called first
+   * @throws {Error} if {@link start}
+   * or {@link startOneOff} was not called first
    */
   stop() {
     if (this.changesResultIterator) {

--- a/cloudant/features/changesResultIterator.ts
+++ b/cloudant/features/changesResultIterator.ts
@@ -22,7 +22,6 @@ import { promisify } from 'util';
 import CloudantV1 = require('../v1');
 
 enum TransientErrorSuppression {
-  /** @internal */
   ALWAYS,
   NEVER,
   TIMER,

--- a/index.ts
+++ b/index.ts
@@ -24,6 +24,7 @@ export {
   BasicAuthenticator,
   IamAuthenticator,
   CouchdbSessionAuthenticator,
+  CouchdbSessionAuthenticatorOptions,
 } from './auth';
 
 export { ChangesFollower } from './cloudant/features/changesFollower';

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "test-ci": "jest --runInBand --testNamePattern='^((?!@slow).)*$' test/",
     "test-unit-ci": "jest --runInBand test/unit/",
     "test-integration-ci": "jest --runInBand --no-colors --testNamePattern='^((?!@slow).)*$' --json test/integration > test-output.log",
-    "typedoc": "typedoc --theme default --entryPointStrategy expand --excludeExternals --tsconfig tsconfig.json --out apidocs auth cloudant --includeVersion"
+    "typedoc": "typedoc"
   },
   "license": "Apache-2.0",
   "engines": {

--- a/scripts/typedoc/generate_typedoc.sh
+++ b/scripts/typedoc/generate_typedoc.sh
@@ -1,9 +1,0 @@
-
-# For each service belonging to your project, add a command like the commented out example below.
-# Replace "service-name/v1.ts" with the source directory name and version for the service.
-#./node_modules/.bin/typedoc --mode file --theme ./scripts/typedoc/theme --excludeExternals \
-#    --out ./service-name/v1.ts --target "ES5"
-
-# List the commands for each service here:
-npx typedoc --theme default --entryPointStrategy expand --excludeExternals \
-    --tsconfig tsconfig.json --out apidocs auth cloudant --includeVersion

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,0 +1,10 @@
+{
+    "theme": "default",
+    "entryPointStrategy": "expand",
+    "excludeExternals": true,
+    "tsconfig": "tsconfig.json",
+    "out": "apidocs",
+    "includeVersion": true,
+    "entryPoints": ["index.ts"],
+    "excludeInternal": true
+}


### PR DESCRIPTION
## PR summary

These changes will hide the internal documentation of changes follower from our following published Typedoc.

The locally generated result can be downloaded here: 
[apidocs.zip](https://github.com/IBM/cloudant-node-sdk/files/13950856/apidocs.zip) and can be compared to our [latest published Typedoc](https://ibm.github.io/cloudant-node-sdk/docs/latest/).

## PR Checklist

Please make sure that your PR fulfills the following requirements:

- [x] The commit message follows the
[Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [x] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

## What is the new behavior?
<!-- Please describe the new behavior after your change. -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and
migration path for existing applications below. -->

## Other information

<!-- Please add any additional information that would help reviewers evaluate
your PR-->
