### PR TITLE
docs: correct parameter name in API change example

### DIFF
--- a/api-changes.md
+++ b/api-changes.md
@@ -831,7 +831,7 @@ to the new SDK name format model with the corrected case convention.
 const vduFunction: string = 'function (doc) { if (!doc.email) { throw({ forbidden: "Users must have an email." }); }}';
 
 const designDocument: CloudantV1.DesignDocument = CloudantV1.DesignDocument.deserialize({
-  validateDocUpdate: vduFunction
+  validate_doc_update: vduFunction
 });
 
 service.putDesignDocument({


### PR DESCRIPTION
## PR summary

<!-- please include a brief summary of the changes in this PR -->

Fixes: #1605 

**Note: An existing issue is [required](https://github.com/IBM/cloudant-node-sdk/blob/main/CONTRIBUTING.md#PRs) before opening a PR.**

## PR Checklist

Please make sure that your PR fulfills the following requirements:

- [x] The commit message follows the
[Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features) - N/A docs
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [x] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

Doc `0.9.0` migration example incorrectly used `validateDocUpdate`.

## What is the new behavior?
<!-- Please describe the new behavior after your change. -->

Docs `0.9.0`migration example correctly uses `validate_doc_update`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and
migration path for existing applications below. -->

## Other information

<!-- Please add any additional information that would help reviewers evaluate
your PR-->
