### PR TITLE
build: switch from required to imports in custom lib modules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -62,6 +62,7 @@ module.exports = {
         'no-underscore-dangle': 'off',
         'prefer-const': 'error',
         'prettier/prettier': 'error',
+        '@typescript-eslint/no-require-imports': 'error',
       },
     },
     // TypeScript specific rules
@@ -84,7 +85,6 @@ module.exports = {
         'prettier',
       ],
       'rules': {
-        '@typescript-eslint/no-require-imports': 'error',
         '@typescript-eslint/naming-convention': 'off',
         '@typescript-eslint/no-unused-vars': 'off',
         'no-param-reassign': 'off',
@@ -109,6 +109,9 @@ module.exports = {
       },
       'plugins': ['jest'],
       'extends': ['plugin:jest/recommended', 'plugin:jest/style'],
+      'rules': {
+        '@typescript-eslint/no-require-imports': 'off',
+      },
     },
     {
       'files': ['test/**/*.test.js'],
@@ -116,8 +119,6 @@ module.exports = {
         'jest/expect-expect': 'off',
         'jest/no-conditional-expect': 'off',
         'jest/no-done-callback': 'off',
-        'jest/no-standalone-expect': 'off',
-        'jest/no-try-expect': 'off',
       },
     },
     {
@@ -134,21 +135,6 @@ module.exports = {
       ],
       'rules': {
         'no-console': 'off',
-      },
-    },
-    {
-      'files': ['test/examples/src/js/*.js'],
-      'rules': {
-        'dot-notation': 'off',
-      },
-    },
-    {
-      'files': [
-        'test/examples/src/js/CreateDbAndDoc.js',
-        'test/examples/src/ts/CreateDbAndDoc.ts',
-      ],
-      'rules': {
-        'prefer-template': 'off',
       },
     },
   ],

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -84,6 +84,7 @@ module.exports = {
         'prettier',
       ],
       'rules': {
+        '@typescript-eslint/no-require-imports': 'error',
         '@typescript-eslint/naming-convention': 'off',
         '@typescript-eslint/no-unused-vars': 'off',
         'no-param-reassign': 'off',

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "stubs/.+\\.json|package-lock.json|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2024-03-20T15:11:17Z",
+  "generated_at": "2024-09-18T15:57:23Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -156,7 +156,7 @@
         "hashed_secret": "fc5177639d71196391dd9f4997bc4f240eb29366",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 158,
+        "line_number": 165,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/auth/sessionTokenManager.ts
+++ b/auth/sessionTokenManager.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { OutgoingHttpHeaders } from 'http';
+import { OutgoingHttpHeaders } from 'node:http';
 import {
   getCurrentTime,
   TokenManager,

--- a/cloudant/features/changesFollower.ts
+++ b/cloudant/features/changesFollower.ts
@@ -13,13 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { ChangesResultItem, PostChangesParams } from '../v1';
+import {
+  default as CloudantV1,
+  ChangesResultItem,
+  PostChangesParams,
+} from '../v1';
 import { Stream } from './stream';
 import { ChangesParamsHelper } from './changesParamsHelper';
 import { ChangesResultItemStream } from './changesResultItemStream';
-import { pipeline, Readable } from 'stream';
+import { pipeline, Readable } from 'node:stream';
 import { ChangesResultIterableIterator } from './changesResultIterator';
-import CloudantV1 = require('../v1');
 
 /** @internal */
 export enum Mode {

--- a/cloudant/features/changesResultItemStream.ts
+++ b/cloudant/features/changesResultItemStream.ts
@@ -15,9 +15,9 @@
  */
 
 import { Stream } from './stream';
-import { TransformCallback } from 'stream';
+import { TransformCallback } from 'node:stream';
 import { validateParams } from 'ibm-cloud-sdk-core';
-import CloudantV1 = require('../v1');
+import CloudantV1 from '../v1';
 
 export class ChangesResultItemStream extends Stream<CloudantV1.ChangesResultItem> {
   _transform(

--- a/cloudant/features/changesResultIterator.ts
+++ b/cloudant/features/changesResultIterator.ts
@@ -17,9 +17,8 @@
 import { ChangesParamsHelper } from './changesParamsHelper';
 import { ChangesFollower, Mode } from './changesFollower';
 import { getNewLogger } from 'ibm-cloud-sdk-core';
-import { PostChangesParams } from '../v1';
-import { promisify } from 'util';
-import CloudantV1 = require('../v1');
+import { default as CloudantV1, PostChangesParams } from '../v1';
+import { promisify } from 'node:util';
 
 enum TransientErrorSuppression {
   ALWAYS,

--- a/cloudant/features/stream.ts
+++ b/cloudant/features/stream.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Transform, TransformOptions } from 'stream';
+import { Transform, TransformOptions } from 'node:stream';
 
 export class Stream<T> extends Transform {
   constructor(opts?: TransformOptions) {

--- a/index.ts
+++ b/index.ts
@@ -18,7 +18,7 @@
  * @module cloudant-node-sdk
  */
 
-export import CloudantV1 = require('./cloudant/v1');
+export { default as CloudantV1 } from './cloudant/v1';
 
 export {
   BasicAuthenticator,

--- a/lib/cloudantBaseService.ts
+++ b/lib/cloudantBaseService.ts
@@ -19,8 +19,8 @@ import { Authenticator, BaseService, UserOptions } from 'ibm-cloud-sdk-core';
 import { CookieJar } from 'tough-cookie';
 import { CouchdbSessionAuthenticator } from '../auth';
 import { getSdkHeaders } from './common';
-import { Agent as HttpsAgent } from 'https';
-import { Agent as HttpAgent } from 'http';
+import { Agent as HttpsAgent } from 'node:https';
+import { Agent as HttpAgent } from 'node:http';
 
 /**
  * Set default timeout to 2.5 minutes (= 150 000 ms)

--- a/lib/common.ts
+++ b/lib/common.ts
@@ -14,9 +14,8 @@
  * limitations under the License.
  */
 
-import * as os from 'os';
-// tslint:disable-next-line:no-var-requires
-const pkg = require('../package.json');
+import { platform, release, arch } from 'node:os';
+import { version } from '../package.json';
 
 export type SdkHeaders = {
   'User-Agent': string;
@@ -32,10 +31,10 @@ export function getSdkHeaders(
   operationId: string
 ): SdkHeaders | {} {
   const sdkName = 'cloudant-node-sdk';
-  const sdkVersion = pkg.version;
-  const osName = os.platform();
-  const osVersion = os.release();
-  const osArch = os.arch();
+  const sdkVersion = version;
+  const osName = platform();
+  const osVersion = release();
+  const osArch = arch();
   const nodeVersion = process.version;
 
   const headers = {

--- a/test/examples/src/features/js/initialize.js
+++ b/test/examples/src/features/js/initialize.js
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { ChangesFollower, CloudantV1 } from '../../../../../index';
+const { ChangesFollower, CloudantV1 } = require('../../../../../index');
 
 const client = CloudantV1.newInstance();
 const changesParams = {

--- a/test/examples/src/features/js/start.js
+++ b/test/examples/src/features/js/start.js
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { ChangesFollower, CloudantV1 } from '../../../../../index';
+const { ChangesFollower, CloudantV1 } = require('../../../../../index');
 
 const client = CloudantV1.newInstance();
 const changesParams = {

--- a/test/examples/src/features/js/startAndProcess.js
+++ b/test/examples/src/features/js/startAndProcess.js
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { ChangesFollower, CloudantV1 } from '../../../../../index';
+const { ChangesFollower, CloudantV1 } = require('../../../../../index');
 const { Writable } = require('node:stream');
 const { pipeline } = require('node:stream/promises');
 

--- a/test/examples/src/features/js/startOneOff.js
+++ b/test/examples/src/features/js/startOneOff.js
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { ChangesFollower, CloudantV1 } from '../../../../../index';
+const { ChangesFollower, CloudantV1 } = require('../../../../../index');
 
 const client = CloudantV1.newInstance();
 const changesParams = {

--- a/test/examples/src/features/js/startOneOffAndProcess.js
+++ b/test/examples/src/features/js/startOneOffAndProcess.js
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { ChangesFollower, CloudantV1 } from '../../../../../index';
+const { ChangesFollower, CloudantV1 } = require('../../../../../index');
 const { Writable } = require('node:stream');
 const { pipeline } = require('node:stream/promises');
 

--- a/test/examples/src/features/js/stop.js
+++ b/test/examples/src/features/js/stop.js
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { ChangesFollower, CloudantV1 } from '../../../../../index';
+const { ChangesFollower, CloudantV1 } = require('../../../../../index');
 const { Writable } = require('node:stream');
 const { pipeline } = require('node:stream/promises');
 

--- a/test/unit/cloudantBaseService.test.js
+++ b/test/unit/cloudantBaseService.test.js
@@ -129,7 +129,7 @@ describe('Test CloudantBaseService', () => {
     assert.notDeepStrictEqual(auth.tokenManager, tokenManager);
   });
 
-  it('Apply SDK UA header', () => {
+  it('Apply SDK UA header', async () => {
     const auth = new CouchdbSessionAuthenticator({
       username: 'test',
       password: 'user', // pragma: allowlist secret
@@ -145,7 +145,7 @@ describe('Test CloudantBaseService', () => {
     auth.tokenManager.requestWrapperInstance.sendRequest = sinon.spy();
 
     try {
-      auth.authenticate();
+      await auth.authenticate();
       // eslint-disable-next-line no-empty
     } catch (e) {}
     assert.ok(auth.tokenManager.requestWrapperInstance.sendRequest.calledOnce);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "target": "es2022",                    /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', or 'ESNEXT'. */
     "module": "node16",                    /* Specify module code generation: 'none', commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
     "lib": [
-        "es2023",
+        "es2022",
         "dom"
     ],
 
@@ -21,6 +21,7 @@
     /* Module Resolution Options */
     "moduleResolution": "node16",          /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
     "types": ["node"],                     /* Type declaration files to be included in compilation. */
+    "resolveJsonModule": true,             /* Allows importing modules with a .json extension. */
     "esModuleInterop": true
   },
   "exclude": [


### PR DESCRIPTION
## PR summary

This is a build refactoring work that makes sure we are using esm style imports in all of our custom modules and consistently using cjs `required` across tests.

## PR Checklist

Please make sure that your PR fulfills the following requirements:

- [x] The commit message follows the
[Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [x] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

## What is the new behavior?
<!-- Please describe the new behavior after your change. -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and
migration path for existing applications below. -->

## Other information

<!-- Please add any additional information that would help reviewers evaluate
your PR-->
