### PR TITLE
Fix named import of CloudantV1

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -18,7 +18,8 @@
  * @module cloudant-node-sdk
  */
 
-export { default as CloudantV1 } from './cloudant/v1';
+import { default as CloudantV1 } from './cloudant/v1';
+export { CloudantV1 };
 
 export {
   BasicAuthenticator,


### PR DESCRIPTION
## PR summary

The named import of `CloudantV1` for esm modules was broken in 0.10.2, this patch remediates the degradation 

Fixes: #1631

**Note: An existing issue is [required](https://github.com/IBM/cloudant-node-sdk/blob/main/CONTRIBUTING.md#PRs) before opening a PR.**

## PR Checklist

Please make sure that your PR fulfills the following requirements:

- [x] The commit message follows the
[Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

## What is the new behavior?
<!-- Please describe the new behavior after your change. -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and
migration path for existing applications below. -->

## Other information

<!-- Please add any additional information that would help reviewers evaluate
your PR-->
