### PR TITLE
feat: add interceptor for error responses

### DIFF
--- a/lib/cloudantBaseService.ts
+++ b/lib/cloudantBaseService.ts
@@ -1,5 +1,5 @@
 /**
- * © Copyright IBM Corporation 2020, 2022. All Rights Reserved.
+ * © Copyright IBM Corporation 2020, 2024. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,10 +17,11 @@
 // eslint-disable-next-line max-classes-per-file
 import { Authenticator, BaseService, UserOptions } from 'ibm-cloud-sdk-core';
 import { CookieJar } from 'tough-cookie';
-import { CouchdbSessionAuthenticator } from '../auth';
-import { getSdkHeaders } from './common';
 import { Agent as HttpsAgent } from 'node:https';
 import { Agent as HttpAgent } from 'node:http';
+import { CouchdbSessionAuthenticator } from '../auth';
+import { errorResponseInterceptor } from './errorResponseInterceptor';
+import { getSdkHeaders } from './common';
 
 /**
  * Set default timeout to 2.5 minutes (= 150 000 ms)
@@ -112,6 +113,12 @@ export default abstract class CloudantBaseService extends BaseService {
     super(userOptions);
     this.timeout = userOptions.timeout;
     this.configureSessionAuthenticator();
+
+    // Add response interceptor for error transforms
+    this.getHttpClient().interceptors.response.use(
+      (response) => response,
+      (axiosError) => errorResponseInterceptor(axiosError)
+    );
   }
 
   public getTimeout() {
@@ -142,6 +149,11 @@ export default abstract class CloudantBaseService extends BaseService {
     // Read external configuration and set as request defaults.
     super.configureService(serviceName);
     this.configureSessionAuthenticator();
+    // Add response interceptor for error transforms
+    this.getHttpClient().interceptors.response.use(
+      (response) => response,
+      (axiosError) => errorResponseInterceptor(axiosError)
+    );
   }
 
   /**

--- a/lib/errorResponseInterceptor.ts
+++ b/lib/errorResponseInterceptor.ts
@@ -1,0 +1,55 @@
+/**
+ * © Copyright IBM Corporation 2024. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export function errorResponseInterceptor(axiosError) {
+  if (
+    axiosError.response && // must have a response
+    axiosError.response.status >= 400 &&
+    // must have data:
+    axiosError.response.data &&
+    // must be a JSON
+    // which also implies Content-Type starts with application/json:
+    axiosError.config.responseType === 'json' &&
+    // must be a valid JSON:
+    // which also implies it is not a HEAD method:
+    axiosError.response.data instanceof Object &&
+    !axiosError.response.data.trace
+  ) {
+    // Map the error/reason if available
+    // and not already have errors array:
+    if (!axiosError.response.data.errors && axiosError.response.data.error) {
+      const error = {
+        code: axiosError.response.data.error,
+        message: axiosError.response.data.error,
+      };
+      if (axiosError.response.data.reason) {
+        error.message += `: ${axiosError.response.data.reason}`;
+      }
+      // Add the new error as part of an errors array.
+      axiosError.response.data.errors = [error];
+    }
+    if (axiosError.response.data.errors) {
+      // Map x-couch-request-id if available to the trace field
+      const trace = axiosError.response.headers['x-couch-request-id'];
+      if (trace) {
+        // Trace should be omitted if there is no value
+        axiosError.response.data.trace = trace;
+      }
+    }
+  }
+
+  return Promise.reject(axiosError);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "eslint-plugin-prettier": "5.2.1",
         "jest": "29.7.0",
         "jest-junit": "16.0.0",
+        "nock": "13.5.5",
         "prettier": "3.3.3",
         "sinon": "19.0.2",
         "ts-jest": "29.2.5",
@@ -5287,6 +5288,12 @@
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true
     },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "dev": true
+    },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -5659,6 +5666,20 @@
       "dev": true,
       "dependencies": {
         "@sinonjs/commons": "^3.0.1"
+      }
+    },
+    "node_modules/nock": {
+      "version": "13.5.5",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-13.5.5.tgz",
+      "integrity": "sha512-XKYnqUrCwXC8DGG1xX4YH5yNIrlh9c065uaMZZHUoeUUINTOyt+x/G+ezYk0Ft6ExSREVIs+qBJDK503viTfFA==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.1.0",
+        "json-stringify-safe": "^5.0.1",
+        "propagate": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.13"
       }
     },
     "node_modules/node-int64": {
@@ -6161,6 +6182,15 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/propagate": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
+      "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/proxy-from-env": {

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "eslint-plugin-prettier": "5.2.1",
     "jest": "29.7.0",
     "jest-junit": "16.0.0",
+    "nock": "13.5.5",
     "prettier": "3.3.3",
     "sinon": "19.0.2",
     "ts-jest": "29.2.5",

--- a/test/unit/errorResponseInterceptor.test.js
+++ b/test/unit/errorResponseInterceptor.test.js
@@ -1,0 +1,419 @@
+/**
+ * © Copyright IBM Corporation 2024. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const assert = require('assert');
+const nock = require('nock');
+const { Writable } = require('node:stream');
+const { pipeline } = require('node:stream/promises');
+const { IncomingMessage } = require('http');
+const { getClient } = require('./features/testDataProviders.js');
+const {
+  errorResponseInterceptor,
+} = require('../../lib/errorResponseInterceptor.ts');
+
+// Constants used by most of the test cases:
+const TRACE = '338da230c5';
+const DB_NAME = 'trial-db';
+const DOC_ID = 'trial-doc';
+const DOCUMENT_REQUEST = { db: DB_NAME, docId: DOC_ID };
+const DB_URL = `http://localhost:5984/${DB_NAME}`;
+const ERROR_CODE = 459; // not a common error code because nock is able to fail with that too
+
+let service;
+const numberOfBaseInterceptors = 1; // responseInterceptor from core exists already
+
+function getCases() {
+  return [
+    {
+      name: 'test_augment_error',
+      mockResponse: { error: 'foo' },
+      expectedResponse: {
+        error: 'foo',
+        errors: [{ message: 'foo', code: 'foo' }],
+      },
+      mockHeaders: undefined,
+      expectedHeaders: { 'content-type': 'application/json' },
+    },
+    {
+      name: 'test_augment_json_charset',
+      mockResponse: { error: 'foo', reason: 'Bar.' },
+      expectedResponse: {
+        error: 'foo',
+        reason: 'Bar.',
+        errors: [{ code: 'foo', message: 'foo: Bar.' }],
+        trace: TRACE,
+      },
+      mockHeaders: {
+        'x-couch-request-id': TRACE,
+        'Content-Type': 'application/json; charset=utf-8',
+      },
+      expectedHeaders: {
+        'x-couch-request-id': TRACE,
+        'content-type': 'application/json; charset=utf-8',
+      },
+    },
+    {
+      name: 'test_no_augment_stream',
+      requestFunction: 'getDocumentAsStream',
+      mockResponse: { error: 'foo', reason: 'Bar.' },
+      // for now in Node we don't augment stream responses:
+      expectedResponse: { error: 'foo', reason: 'Bar.' },
+      mockHeaders: { 'x-couch-request-id': TRACE },
+      expectedHeaders: {
+        'x-couch-request-id': TRACE,
+        'content-type': 'application/json',
+      },
+    },
+    {
+      name: 'test_no_augment_success',
+      responseCode: 200,
+      mockResponse: {},
+      expectedResponse: {},
+      mockHeaders: { 'x-couch-request-id': TRACE },
+      expectedHeaders: {
+        'x-couch-request-id': TRACE,
+        'content-type': 'application/json',
+      },
+    },
+    {
+      name: 'test_no_augment_head',
+      requestFunction: 'headDocument',
+      // axios turns undefined HEAD response "bodies" to empty strings:
+      expectedResponse: '',
+      mockHeaders: { 'x-couch-request-id': TRACE },
+      expectedHeaders: {
+        'x-couch-request-id': TRACE,
+      },
+    },
+    {
+      name: 'test_no_augment_non_json',
+      mockResponse: 'foo=Bar.',
+      expectedResponse: 'foo=Bar.',
+      mockHeaders: {
+        'x-couch-request-id': TRACE,
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      expectedHeaders: {
+        'x-couch-request-id': TRACE,
+        'content-type': 'application/x-www-form-urlencoded',
+      },
+    },
+    {
+      name: 'test_no_augment_no_content_type',
+      // body should not be a JSON otherwise content-type becames application/json automatically:
+      mockResponse: 'fooBar',
+      expectedResponse: 'fooBar',
+      mockHeaders: { 'x-couch-request-id': TRACE },
+      expectedHeaders: { 'x-couch-request-id': TRACE },
+    },
+    {
+      name: 'test_no_augment_no_error',
+      mockResponse: { reason: 'Bar.' },
+      expectedResponse: { reason: 'Bar.' },
+      mockHeaders: { 'x-couch-request-id': TRACE },
+      expectedHeaders: {
+        'x-couch-request-id': TRACE,
+        'content-type': 'application/json',
+      },
+    },
+    {
+      name: 'test_no_augment_invalid_json',
+      expectedResponseCode: -1, // error code will be undefined due to a SyntaxError
+      mockResponse: '{"err',
+      // response result is undefined here
+      expectedResponse: undefined,
+      // but the response message should have SyntaxError
+      expectedResponseMessage: 'SyntaxError',
+      mockHeaders: {
+        'x-couch-request-id': TRACE,
+        'Content-Type': 'application/json',
+      },
+      expectedHeaders: undefined,
+    },
+    {
+      name: 'test_no_augment_no_error_no_header',
+      mockResponse: { reason: 'Qux.', foo: 'bar' },
+      expectedResponse: { reason: 'Qux.', foo: 'bar' },
+      mockHeaders: undefined,
+      // content-type is added to the GET request responses by nock
+      expectedHeaders: { 'content-type': 'application/json' },
+    },
+    {
+      name: 'test_augment_error_reason',
+      mockResponse: { error: 'foo', reason: 'Bar.' },
+      expectedResponse: {
+        error: 'foo',
+        reason: 'Bar.',
+        errors: [{ code: 'foo', message: 'foo: Bar.' }],
+        // `trace` is not added to the body because there were neither `trace` nor `x-couch-request-id`
+      },
+      mockHeaders: undefined,
+      // content-type is added to the GET request responses by nock
+      expectedHeaders: { 'content-type': 'application/json' },
+    },
+    {
+      name: 'test_no_augment_id_only',
+      mockResponse: {},
+      expectedResponse: {
+        // `errors` is not added to the body because there was no `error`
+        // `trace` is not added to the body because there were neither `trace` nor `x-couch-request-id`
+      },
+      mockHeaders: { 'x-couch-request-id': TRACE },
+      // content-type is added to the GET request responses by nock
+      expectedHeaders: {
+        'x-couch-request-id': TRACE,
+        'content-type': 'application/json',
+      },
+    },
+    {
+      name: 'test_augment_error_with_trace',
+      mockResponse: { error: 'foo' },
+      expectedResponse: {
+        error: 'foo',
+        errors: [{ message: 'foo', code: 'foo' }],
+        trace: TRACE,
+      },
+      mockHeaders: { 'x-couch-request-id': TRACE },
+      expectedHeaders: {
+        'x-couch-request-id': TRACE,
+        'content-type': 'application/json',
+      },
+    },
+    {
+      name: 'test_augment_error_reason_with_trace',
+      mockResponse: { error: 'foo', reason: 'Bar.' },
+      expectedResponse: {
+        error: 'foo',
+        reason: 'Bar.',
+        errors: [{ message: 'foo: Bar.', code: 'foo' }],
+        trace: TRACE,
+      },
+      mockHeaders: {
+        'x-couch-request-id': TRACE,
+      },
+      expectedHeaders: {
+        'x-couch-request-id': TRACE,
+        'content-type': 'application/json',
+      },
+    },
+    {
+      name: 'test_no_augment_existing_trace',
+      // trace diffs from x-couch-request-id in header:
+      mockResponse: { error: 'foo', reason: 'Bar.', trace: 'fooBar' },
+      expectedResponse: { error: 'foo', reason: 'Bar.', trace: 'fooBar' },
+      mockHeaders: {
+        'x-couch-request-id': TRACE,
+      },
+      expectedHeaders: {
+        'x-couch-request-id': TRACE,
+        'content-type': 'application/json',
+      },
+    },
+    {
+      name: 'test_no_augment_existing_errors_no_id',
+      mockResponse: {
+        error: 'baz',
+        reason: 'Qux.',
+        errors: [{ code: 'foo', message: 'Bar.' }],
+      },
+      expectedResponse: {
+        error: 'baz',
+        reason: 'Qux.',
+        errors: [{ code: 'foo', message: 'Bar.' }],
+      },
+      mockHeaders: undefined, // trace is not appended to the expected response
+      expectedHeaders: {
+        'content-type': 'application/json',
+      },
+    },
+    {
+      name: 'test_augment_trace_existing_errors',
+      mockResponse: {
+        error: 'baz',
+        reason: 'Qux.',
+        errors: [{ code: 'foo', message: 'Bar.' }],
+      },
+      expectedResponse: {
+        error: 'baz',
+        reason: 'Qux.',
+        errors: [{ code: 'foo', message: 'Bar.' }],
+        trace: TRACE,
+      },
+      mockHeaders: { 'x-couch-request-id': TRACE },
+      expectedHeaders: {
+        'x-couch-request-id': TRACE,
+        'content-type': 'application/json',
+      },
+    },
+    {
+      name: 'test_augment_empty_reason_with_trace',
+      mockResponse: {
+        error: 'baz',
+        reason: '',
+      },
+      expectedResponse: {
+        error: 'baz',
+        reason: '',
+        errors: [{ code: 'baz', message: 'baz' }],
+        trace: TRACE,
+      },
+      mockHeaders: { 'x-couch-request-id': TRACE },
+      expectedHeaders: {
+        'x-couch-request-id': TRACE,
+        'content-type': 'application/json',
+      },
+    },
+  ];
+}
+
+// Take the result stream from an error
+// and convert it to a JSON object
+async function getJsonErrorFromStreamError(streamError) {
+  let data = '';
+  await pipeline(
+    streamError.result,
+    new Writable({
+      write: (c, e, cb) => {
+        data += c;
+        cb();
+      },
+    })
+  );
+  return JSON.parse(data);
+}
+
+describe('test errorResponseInterceptor', () => {
+  beforeEach(() => {
+    nock.cleanAll();
+    service = getClient(); // new client at each run
+  });
+
+  it.each(getCases())('$name', async (test) => {
+    // prepare request function name, response method, response code
+    const requestFunction = test.requestFunction
+      ? test.requestFunction
+      : 'getDocument';
+    const responseMethod = requestFunction.split(/(?=[A-Z])/)[0];
+    const responseCode = test.responseCode ? test.responseCode : ERROR_CODE;
+    // mock response
+    nock(DB_URL)
+      [responseMethod](`/${DOC_ID}`)
+      .reply(responseCode, test.mockResponse, test.mockHeaders);
+    let responseIsSaved = false;
+
+    // declare variables for assertions
+    let responseStatus;
+    let responseHeaders;
+    let responseResult;
+    let responseMessage;
+    let responseStack;
+
+    await service[requestFunction](DOCUMENT_REQUEST)
+      .then((response) => {
+        responseStatus = response.status;
+        responseHeaders = response.headers.toJSON();
+        responseResult = response.result;
+        responseIsSaved = true;
+      })
+      .catch(async (onrejected) => {
+        if (!responseIsSaved) {
+          responseStatus = onrejected.status;
+          if (onrejected.headers) {
+            responseHeaders = onrejected.headers.toJSON();
+          }
+          // Get JSON when result is a stream:
+          if (onrejected.result instanceof IncomingMessage) {
+            responseResult = await getJsonErrorFromStreamError(onrejected);
+          } else {
+            responseResult = onrejected.result;
+          }
+          responseMessage = onrejected.message;
+          responseStack = onrejected.stack;
+          responseIsSaved = true;
+        }
+      });
+    // response was saved in either the then or the catch block:
+    assert.ok(responseIsSaved);
+    if (test.expectedResponseCode === -1) {
+      // responseStatus is undefined for edge case test_no_augment_invalid_json:
+      assert.equal(responseStatus, undefined);
+    } else {
+      assert.equal(responseStatus, responseCode);
+    }
+    assert.deepEqual(responseHeaders, test.expectedHeaders);
+    assert.deepStrictEqual(responseResult, test.expectedResponse);
+    if (test.expectedResponseMessage) {
+      // check message includes SyntaxError for edge case test_no_augment_invalid_json:
+      assert.ok(responseMessage.includes(test.expectedResponseMessage));
+      assert.ok(!responseStack.includes('errorResponseInterceptor'));
+    }
+  });
+
+  it('test_added', async () => {
+    const expectedNumberOfResponseInterceptors = numberOfBaseInterceptors + 1;
+    assert.strictEqual(
+      service.requestWrapperInstance.axiosInstance.interceptors.response
+        .handlers.length,
+      expectedNumberOfResponseInterceptors
+    );
+    // check whether errorResponseInterceptor is set as a new interceptor for rejected responses
+    const actualErrorResponseInterceptor =
+      service.requestWrapperInstance.axiosInstance.interceptors.response
+        .handlers[expectedNumberOfResponseInterceptors - 1].rejected;
+    assert.deepStrictEqual(
+      Object.getPrototypeOf(actualErrorResponseInterceptor),
+      Object.getPrototypeOf(errorResponseInterceptor)
+    );
+  });
+  it('test_added_via_configureService', async () => {
+    // Before configureService:
+    let expectedNumberOfResponseInterceptors = numberOfBaseInterceptors + 1;
+    assert.strictEqual(
+      service.requestWrapperInstance.axiosInstance.interceptors.response
+        .handlers.length,
+      expectedNumberOfResponseInterceptors
+    );
+    // check whether errorResponseInterceptor is set as a new interceptor for rejected responses
+    let actualErrorResponseInterceptor =
+      service.requestWrapperInstance.axiosInstance.interceptors.response
+        .handlers[expectedNumberOfResponseInterceptors - 1].rejected;
+    assert.deepStrictEqual(
+      Object.getPrototypeOf(actualErrorResponseInterceptor),
+      Object.getPrototypeOf(errorResponseInterceptor)
+    );
+    // get number of service response interceptors before configureService
+    expectedNumberOfResponseInterceptors =
+      service.requestWrapperInstance.axiosInstance.interceptors.response
+        .handlers.length; // after configureService we should get the same number of interceptors
+
+    service.configureService('apple'); // configureService overrides the interceptors as well
+
+    // After configureService:
+    assert.strictEqual(
+      service.requestWrapperInstance.axiosInstance.interceptors.response
+        .handlers.length,
+      expectedNumberOfResponseInterceptors
+    );
+    // check whether errorResponseInterceptor is set as a new interceptor for rejected responses
+    actualErrorResponseInterceptor =
+      service.requestWrapperInstance.axiosInstance.interceptors.response
+        .handlers[expectedNumberOfResponseInterceptors - 1].rejected;
+    assert.deepStrictEqual(
+      Object.getPrototypeOf(actualErrorResponseInterceptor),
+      Object.getPrototypeOf(errorResponseInterceptor)
+    );
+  });
+});

--- a/test/unit/features/testDataProviders.js
+++ b/test/unit/features/testDataProviders.js
@@ -1,5 +1,5 @@
 /**
- * © Copyright IBM Corporation 2022. All Rights Reserved.
+ * © Copyright IBM Corporation 2022, 2024. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -75,7 +75,7 @@ const { NoAuthAuthenticator } = core;
 function getCloudantServiceOptions() {
   return {
     authenticator: new NoAuthAuthenticator(),
-    url: 'http://localhost:5984',
+    serviceUrl: 'http://localhost:5984',
   };
 }
 


### PR DESCRIPTION
## PR summary

Add interceptor for error response augmentation

Fixes: s1003

## PR Checklist

Please make sure that your PR fulfills the following requirements:

- [x] The commit message follows the
[Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?
Cloudant/CouchDB error models are handled by the core with only the `error` field being processed. Obtaining e.g. the `reason` field requires additional user code.

## What is the new behavior?
The error response is augmented with `errors` and `trace` properties.
This improves the way the core handles the error response and enhances the user facing exception string to include the `reason`.
The `trace` is the CouchDB request ID which can be used to correlate with logs.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
The existing error model fields are retained, the new fields are backwards compatible.

<!-- If this PR contains a breaking change, please describe the impact and
migration path for existing applications below. -->

## Other information

Add `errorResponseInterceptor`.
Modify `cloudantBaseService` to apply interceptor.
New tests in `errorResponseInterceptorTest`.
Fix service options on `test/unit/features/testDataProviders.js`.
Add `nock` for testing.
