### PR TITLE
feat!: convert stream error responses

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "stubs/.+\\.json|package-lock.json|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2024-09-18T15:57:23Z",
+  "generated_at": "2024-11-04T12:08:10Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -156,7 +156,7 @@
         "hashed_secret": "fc5177639d71196391dd9f4997bc4f240eb29366",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 165,
+        "line_number": 185,
         "type": "Secret Keyword",
         "verified_result": null
       }


### PR DESCRIPTION
## PR summary

Add interceptor for converting streamed error responses to error objects.

Fixes: s1022

**Note: An existing issue is [required](https://github.com/IBM/cloudant-node-sdk/blob/main/CONTRIBUTING.md#PRs) before opening a PR.**

## PR Checklist

Please make sure that your PR fulfills the following requirements:

- [x] The commit message follows the
[Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

For `*AsStrream` endpoint successful responses are returned as `Readable` streams. In the case of an error the error response body is also provided as a `Readable` by the SDK core. This deviates from the behaviour of errors from all other endpoints and prevents the SDK core from, for example, formatting the error response nicely. It also prevents the new improved error responses from #1646 from functioning for `*AsStream` calls.

## What is the new behavior?
<!-- Please describe the new behavior after your change. -->

For unsuccessful responses the error response body is automatically converted from the `Readable` into a JSON object. This means error handling behaviour can be the same for all endpoints and the enhancements from the error response interceptor and error formatting code paths can be applied to stream error cases as well.

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and
migration path for existing applications below. -->

No change for success responses.
For error responses the error's `result` is converted from a stream to an object.
User code that catches the rejection and tries to process the `result` as a stream will need modification.

## Other information

<!-- Please add any additional information that would help reviewers evaluate
your PR-->

Modified existing tests `error_no_augment_stream` becomes `error_augment_stream`,
Removed obsolete stream handling code in tests.
Modified the interceptor assertion code to account for the presence of two interceptors and validate the ordering.
