### PR TITLE
feat: set x-request-id as error trace

### DIFF
--- a/lib/errorResponseInterceptor.ts
+++ b/lib/errorResponseInterceptor.ts
@@ -52,8 +52,10 @@ export function errorResponseInterceptor(axiosError) {
       axiosError.response.data.errors = [error];
     }
     if (axiosError.response.data.errors) {
-      // Map x-couch-request-id if available to the trace field
-      const trace = axiosError.response.headers['x-couch-request-id'];
+      // Map x-request-id or x-couch-request-id if available to the trace field
+      const trace =
+        axiosError.response.headers['x-request-id'] ||
+        axiosError.response.headers['x-couch-request-id'];
       if (trace) {
         // Trace should be omitted if there is no value
         axiosError.response.data.trace = trace;

--- a/test/unit/errorResponseInterceptor.test.js
+++ b/test/unit/errorResponseInterceptor.test.js
@@ -219,6 +219,42 @@ function getCases() {
       },
     },
     {
+      name: 'test_augment_error_reason_with_trace_request_id',
+      mockResponse: { error: 'foo', reason: 'Bar.' },
+      expectedResponse: {
+        error: 'foo',
+        reason: 'Bar.',
+        errors: [{ message: 'foo: Bar.', code: 'foo' }],
+        trace: TRACE,
+      },
+      mockHeaders: {
+        'x-request-id': TRACE,
+      },
+      expectedHeaders: {
+        'x-request-id': TRACE,
+        'content-type': 'application/json',
+      },
+    },
+    {
+      name: 'test_augment_error_reason_with_trace_request_id_preferred',
+      mockResponse: { error: 'foo', reason: 'Bar.' },
+      expectedResponse: {
+        error: 'foo',
+        reason: 'Bar.',
+        errors: [{ message: 'foo: Bar.', code: 'foo' }],
+        trace: TRACE,
+      },
+      mockHeaders: {
+        'x-request-id': TRACE,
+        'x-couch-request-id': 'anotherid',
+      },
+      expectedHeaders: {
+        'x-request-id': TRACE,
+        'x-couch-request-id': 'anotherid',
+        'content-type': 'application/json',
+      },
+    },
+    {
       name: 'test_no_augment_existing_trace',
       // trace diffs from x-couch-request-id in header:
       mockResponse: { error: 'foo', reason: 'Bar.', trace: 'fooBar' },


### PR DESCRIPTION
## PR summary

<!-- please include a brief summary of the changes in this PR -->

If the `x-request-id` header is on a response use it to set the error `trace` field (in preference to `x-couch-request-id`, but still use `x-couch-request-id` if there is no `x-request-id`).

Fixes: part of s1037

**Note: An existing issue is [required](https://github.com/IBM/cloudant-node-sdk/blob/main/CONTRIBUTING.md#PRs) before opening a PR.**

## PR Checklist

Please make sure that your PR fulfills the following requirements:

- [x] The commit message follows the
[Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

The error `trace` introduced in #1646 only handles CouchDB's `x-couch-request-id` header on responses.

## What is the new behavior?
<!-- Please describe the new behavior after your change. -->

The error `trace` also handles `x-request-id` header on responses.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and
migration path for existing applications below. -->

## Other information

<!-- Please add any additional information that would help reviewers evaluate
your PR-->
