### PR TITLE
perf: use normal feed for one-off changes

### DIFF
--- a/cloudant/features/changesFollower.ts
+++ b/cloudant/features/changesFollower.ts
@@ -1,5 +1,5 @@
 /**
- * © Copyright IBM Corporation 2022. All Rights Reserved.
+ * © Copyright IBM Corporation 2022, 2025. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -214,7 +214,7 @@ export class ChangesFollower {
   private createChangesResultItemsStream(mode: Mode) {
     this.changesResultIterator = new ChangesResultIterableIterator(
       this.client,
-      ChangesParamsHelper.cloneParams(this.params),
+      ChangesParamsHelper.cloneParams(this.params, mode),
       mode,
       this.errorTolerance
     );

--- a/cloudant/features/changesParamsHelper.ts
+++ b/cloudant/features/changesParamsHelper.ts
@@ -1,5 +1,5 @@
 /**
- * © Copyright IBM Corporation 2022, 2023. All Rights Reserved.
+ * © Copyright IBM Corporation 2022, 2025. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
  */
 
 import { PostChangesConstants, PostChangesParams } from '../v1';
+import { Mode } from './changesFollower';
 
 export class ChangesParamsHelper {
   /**
@@ -33,17 +34,17 @@ export class ChangesParamsHelper {
 
   static cloneParams(
     params: PostChangesParams,
+    mode?: Mode,
     since?: string,
     limit?: number
   ): PostChangesParams {
-    return {
+    let clonedParams: PostChangesParams = {
       db: params.db,
       attEncodingInfo: params.attEncodingInfo,
       attachments: params.attachments,
       conflicts: params.conflicts,
       // no descending
       docIds: params.docIds,
-      feed: PostChangesConstants.Feed.LONGPOLL,
       fields: params.fields,
       filter: params.filter,
       // no heartbeat
@@ -54,9 +55,15 @@ export class ChangesParamsHelper {
       seqInterval: params.seqInterval,
       since: since ? since : params.since,
       style: params.style,
-      timeout: this.LONGPOLL_TIMEOUT,
       view: params.view,
     };
+    if (mode === Mode.FINITE) {
+      clonedParams.feed = PostChangesConstants.Feed.NORMAL;
+    } else if (mode === Mode.LISTEN) {
+      clonedParams.feed = PostChangesConstants.Feed.LONGPOLL;
+      clonedParams.timeout = this.LONGPOLL_TIMEOUT;
+    }
+    return clonedParams;
   }
 
   static validateParams(params: PostChangesParams) {

--- a/cloudant/features/changesResultIterator.ts
+++ b/cloudant/features/changesResultIterator.ts
@@ -191,6 +191,7 @@ export class ChangesResultIterableIterator
       this.client.postChanges(
         ChangesParamsHelper.cloneParams(
           this.params,
+          this.mode,
           this.since,
           this.countDown && this.countDown < this.params.limit
             ? this.countDown

--- a/test/unit/features/changesFollower.test.js
+++ b/test/unit/features/changesFollower.test.js
@@ -1,5 +1,5 @@
 /**
- * © Copyright IBM Corporation 2022, 2023. All Rights Reserved.
+ * © Copyright IBM Corporation 2022, 2025. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,7 +35,7 @@ const {
   generateSeq,
   generateRandomChangesResults,
   mockAlternatingBatchErrorThenPerpetualSupplier,
-  mockPerptualSupplierRespectingLimit,
+  mockPerpetualSupplierRespectingLimit,
 } = require('./testMocks.js');
 const { getTerminalErrors, getTransientErrors } = require('./mockErrors');
 const { delay } = require('./testUtils');
@@ -573,7 +573,7 @@ describe('Test ChangesFollower', () => {
       // Note size also passed to test parameter generator.
       setBatchSize(50);
       postChangesPromiseMock.mockImplementation(
-        mockPerptualSupplierRespectingLimit
+        mockPerpetualSupplierRespectingLimit
       );
       const changesFollower = new ChangesFollower(service, {
         limit: modeAndLimit.limit,

--- a/test/unit/features/changesParamsHelper.test.js
+++ b/test/unit/features/changesParamsHelper.test.js
@@ -41,6 +41,7 @@ describe('Test ChangesParamsHelper', () => {
     const newLimitParams = ChangesParamsHelper.cloneParams(
       original,
       undefined,
+      undefined,
       newLimit
     );
     expect(newLimitParams).not.toBe(original);
@@ -57,7 +58,11 @@ describe('Test ChangesParamsHelper', () => {
       since: newSince,
       ...params[paramsName],
     });
-    const newSinceParams = ChangesParamsHelper.cloneParams(original, newSince);
+    const newSinceParams = ChangesParamsHelper.cloneParams(
+      original,
+      undefined,
+      newSince
+    );
     expect(newSinceParams).not.toBe(original);
     expect(newSinceParams).not.toEqual(original);
     expect(newSinceParams.since).toEqual(newSince);

--- a/test/unit/features/changesResultIterator.test.js
+++ b/test/unit/features/changesResultIterator.test.js
@@ -29,7 +29,7 @@ const {
   mockPerpetualSupplier,
   perpetualSupplierResponse,
   mockPostChangesError,
-  mockPerptualSupplierRespectingLimit,
+  mockPerpetualSupplierRespectingLimit,
 } = require('./testMocks');
 const {
   ChangesParamsHelper,
@@ -142,7 +142,7 @@ describe.each(getModes())('Test ChangesResultIterator %s', (mode) => {
     });
     beforeEach(() => {
       postChangesPromiseMock.mockImplementation(
-        mockPerptualSupplierRespectingLimit
+        mockPerpetualSupplierRespectingLimit
       );
     });
     it('Limit less than batch size', () => {
@@ -151,6 +151,7 @@ describe.each(getModes())('Test ChangesResultIterator %s', (mode) => {
         service,
         ChangesParamsHelper.cloneParams(
           testParams.MINIMUM.params,
+          mode,
           undefined,
           limit
         ),
@@ -181,6 +182,7 @@ describe.each(getModes())('Test ChangesResultIterator %s', (mode) => {
         service,
         ChangesParamsHelper.cloneParams(
           testParams.MINIMUM.params,
+          mode,
           undefined,
           limit
         ),
@@ -213,6 +215,7 @@ describe.each(getModes())('Test ChangesResultIterator %s', (mode) => {
         service,
         ChangesParamsHelper.cloneParams(
           testParams.MINIMUM.params,
+          mode,
           undefined,
           limit
         ),
@@ -248,6 +251,7 @@ describe.each(getModes())('Test ChangesResultIterator %s', (mode) => {
         service,
         ChangesParamsHelper.cloneParams(
           testParams.MINIMUM.params,
+          undefined,
           undefined,
           limit
         ),

--- a/test/unit/features/testMocks.js
+++ b/test/unit/features/testMocks.js
@@ -131,7 +131,7 @@ function mockPostChangesError(mock, error) {
   mock.mockRejectedValue(error.error);
 }
 
-function mockPerptualSupplierRespectingLimit(opts) {
+function mockPerpetualSupplierRespectingLimit(opts) {
   return getPerpetualSupplierResponse(opts.limit);
 }
 
@@ -145,5 +145,5 @@ module.exports = {
   generateSeq,
   generateRandomChangesResults: mockRandomChangesResult,
   perpetualSupplierResponse,
-  mockPerptualSupplierRespectingLimit,
+  mockPerpetualSupplierRespectingLimit,
 };

--- a/test/unit/features/testParams.js
+++ b/test/unit/features/testParams.js
@@ -1,5 +1,5 @@
 /**
- * © Copyright IBM Corporation 2022, 2023. All Rights Reserved.
+ * © Copyright IBM Corporation 2022, 2025. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,8 @@ const { PostChangesConstants } = require('../../../cloudant/v1.ts');
 const {
   ChangesParamsHelper,
 } = require('../../../cloudant/features/changesParamsHelper.ts');
+
+const { Mode } = require('../../../cloudant/features/changesFollower.ts');
 
 const beginningOfErrorMsg = 'The param';
 const endOfErrorMsg = 'invalid when using ChangesFollower.';
@@ -109,7 +111,7 @@ const testParams = {
     expectedError: `${beginningOfErrorMsg} 'filter=_view' is ${endOfErrorMsg}`,
   },
   VIEW: {
-    isvalid: false,
+    isValid: false,
     params: {
       filter: '_view',
       view: 'foo/bar',
@@ -171,12 +173,16 @@ const testParams = {
   },
 };
 
-function getExpectedParams(params) {
+function getExpectedParams(params, mode) {
   const expectedParams = params;
-  if (params.feed === undefined) {
-    expectedParams.feed = PostChangesConstants.Feed.LONGPOLL;
+  if (mode === Mode.LISTEN) {
+    if (params.feed === undefined) {
+      expectedParams.feed = PostChangesConstants.Feed.LONGPOLL;
+    }
+    expectedParams.timeout = ChangesParamsHelper.LONGPOLL_TIMEOUT;
+  } else if (mode === Mode.FINITE) {
+    expectedParams.feed = PostChangesConstants.Feed.NORMAL;
   }
-  expectedParams.timeout = ChangesParamsHelper.LONGPOLL_TIMEOUT;
   return expectedParams;
 }
 


### PR DESCRIPTION
## PR summary

Use `normal` feed mode for changes follower one-off `FINITE` mode.

Fixes: s1117 / i445

**Note: An existing issue is [required](https://github.com/IBM/cloudant-java-sdk/blob/main/CONTRIBUTING.md#PRs) before opening a PR.**

## PR Checklist

Please make sure that your PR fulfills the following requirements:

- [x] The commit message follows the
[Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [x] Other (please describe) - performance improvement

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

Currently the changes follower uses `longpoll` feed type is for both `start` (`LISTEN`) and `startOneOff` (`FINITE`) cases.

## What is the new behavior?
<!-- Please describe the new behavior after your change. -->

Switch to use the `normal` feed type for `startOneOff` (`FINITE`) mode thereby optimizing the `startOneOff` cases to avoid waiting unnecessarily.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and
migration path for existing applications below. -->

## Other information

<!-- Please add any additional information that would help reviewers evaluate
your PR-->
