### PR TITLE
ci: add Node.js 24 to test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
   test:
     strategy:
       matrix:
-        node: ['20', '22']
+        node: ['20', '22', '24']
     runs-on: ubuntu-latest
     services:
       couchdb:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
       uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
         node-version: ${{ matrix.node }}
-        check-latest: false
+        check-latest: true
         cache: 'npm'
     - name: Setup CouchDB
       shell: bash


### PR DESCRIPTION
## PR summary

Add Node.js `24` to the test matrix

Fixes: part of s1147

## PR Checklist

Please make sure that your PR fulfills the following requirements:

- [x] The commit message follows the
[Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [x] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

No tests on Node.js `24`

## What is the new behavior?
<!-- Please describe the new behavior after your change. -->

Tests on Node.js `24`

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and
migration path for existing applications below. -->

## Other information

<!-- Please add any additional information that would help reviewers evaluate
your PR-->

Node.js `24` will not be a supported platform for cloudant-node-sdk until it moves to LTS (i.e. Node.js consider it production ready) - this just gets us awareness of any issues on Node.js `24` before that switch in October.
