### PR TITLE
build(deps): bump deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.12.5",
       "license": "Apache-2.0",
       "dependencies": {
-        "@types/node": "20.19.8",
+        "@types/node": "20.19.9",
         "ibm-cloud-sdk-core": "5.4.1"
       },
       "devDependencies": {
@@ -3394,9 +3394,9 @@
       "integrity": "sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g=="
     },
     "node_modules/@types/node": {
-      "version": "20.19.8",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.8.tgz",
-      "integrity": "sha512-HzbgCY53T6bfu4tT7Aq3TvViJyHjLjPNaAS3HOuMc9pw97KHsUtXNX4L+wu59g1WnjsZSko35MbEqnO58rihhw==",
+      "version": "20.19.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.9.tgz",
+      "integrity": "sha512-cuVNgarYWZqxRJDQHEB58GEONhOK79QVR/qYx4S7kcUObQvUwvFnYxJuuHUKm2aieN9X3yZB4LZsuYNU1Qphsw==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "node": "^20 || ^22"
   },
   "dependencies": {
-    "@types/node": "20.19.8",
+    "@types/node": "20.19.9",
     "ibm-cloud-sdk-core": "5.4.1"
   },
   "devDependencies": {


### PR DESCRIPTION
## PR summary

- Bumps [nock](https://github.com/nock/nock) from 14.0.5 to 14.0.6.
- Bumps [jest](https://github.com/jestjs/jest/tree/HEAD/packages/jest) from 30.0.4 to 30.0.5.
- Bumps [ibm-cloud-sdk-core](https://github.com/IBM/node-sdk-core) from 5.4.0 to 5.4.1.
- Bumps `@types/node` from 20.19.8 to 20.19.9

Combines #1845, #1846, #1847, #1848