### PR TITLE
ci: configure version bump for docs sub-folder

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -12,3 +12,9 @@ serialize = [
 filename = "README.md"
 search = "{current_version}"
 replace = "{new_version}"
+
+[[tool.bumpversion.files]]
+glob = "docs/*.md"
+ignore_missing_version = true
+search = "{current_version}"
+replace = "{new_version}"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "copymeta": "[ -d 'dist' ] && cp package.json LICENSE README.md dist/",
     "build": "tsc",
     "postbuild": "npm run copymeta",
-    "version": "bump-my-version bump patch --allow-dirty --new-version $npm_package_version && git add README.md .bumpversion.toml",
+    "version": "bump-my-version bump patch --allow-dirty --new-version $npm_package_version && git add README.md .bumpversion.toml docs/*.md",
     "postversion": "npm run copymeta",
     "jest": "jest --runInBand",
     "test": "npm run build && npm run lint && jest --runInBand test/",


### PR DESCRIPTION
## PR summary

Update bump version config for docs sub-folder.

Fixes: part of s1173

## PR Checklist

Please make sure that your PR fulfills the following requirements:

- [x] The commit message follows the
[Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features) - build/docs
- [x] Docs have been added / updated (for bug fixes / features) - build/docs

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [x] Build/CI related changes
- [x] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

Version bumps update the main `README` but not the new `docs` sub-folder.

## What is the new behavior?
<!-- Please describe the new behavior after your change. -->

Docs sub-folder is included in version bumping during release.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and
migration path for existing applications below. -->

## Other information

<!-- Please add any additional information that would help reviewers evaluate
your PR-->

Tested locally with a dry-run and it looks correct.
