### PR TITLE
fix: add default limit to bookmark pagination

### DIFF
--- a/cloudant/features/pagination/basePageIterator.ts
+++ b/cloudant/features/pagination/basePageIterator.ts
@@ -53,7 +53,7 @@ export abstract class BasePageIterator<
     // Set the page size from the supplied params limit
     this.pageSize = this.getPageSize(params);
     // Clone the supplied params into the nextPageParams
-    this.nextPageParams = { ...params };
+    this.nextPageParams = { ...params, limit: this.pageSize };
   }
 
   public async next(
@@ -93,9 +93,7 @@ export abstract class BasePageIterator<
   }
 
   protected getPageSize(params): number {
-    return this.getLimit(params)
-      ? this.getLimit(params)
-      : BasePageIterator.MAX_LIMIT;
+    return this.getLimit(params) || BasePageIterator.MAX_LIMIT;
   }
 
   public [Symbol.asyncIterator](): AsyncIterableIterator<ReadonlyArray<I>> {


### PR DESCRIPTION
## PR summary

<!-- please include a brief summary of the changes in this PR -->

During testing the find pagination feature, it turned out the default limit was not set for the bookmark pagination. This PR intend to fix that bug.

**Note: An existing issue is [required](https://github.com/IBM/cloudant-node-sdk/blob/main/CONTRIBUTING.md#PRs) before opening a PR.**

## PR Checklist

Please make sure that your PR fulfills the following requirements:

- [x] The commit message follows the
[Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

The default limit is not set for the bookmark pagination.

## What is the new behavior?
<!-- Please describe the new behavior after your change. -->

The default limit is set to MAX_LIMIT for the bookmark pagination.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and
migration path for existing applications below. -->

## Other information

<!-- Please add any additional information that would help reviewers evaluate
your PR-->
