### PR TITLE
ci: stop Node 26 from failing workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,7 @@ env:
   WIREMOCK_PORT: 8080
 jobs:
   test:
+    continue-on-error: ${{ matrix.node == '26' }}
     strategy:
       matrix:
         node: ['22', '24', '26']


### PR DESCRIPTION
## PR summary

Add `continue-on-error: true` for Node 26 matrix job to prevent failing the entire workflow

## PR Checklist

Please make sure that your PR fulfills the following requirements:

- [x] The commit message follows the
[Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [x] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

Node 26 is not yet LTS but we test it as part of the matrix to get ahead of any issues.
It is not a required check, but if the job fails it causes the entire test workflow to fail, blocking merges.

## What is the new behavior?
<!-- Please describe the new behavior after your change. -->

Add `continue-on-error` flag to the test job and get a value from `${{ matrix.node == '26' }}` so it is `true` for Node 26 (i.e. the workflow can continue even if Node 26 fails).
It evaluates to `false` for Node 22 and 24 preserving the existing behaviour since we need both those checks to pass we can shortcut and stop work if one of them fails.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and
migration path for existing applications below. -->

## Other information

<!-- Please add any additional information that would help reviewers evaluate
your PR-->
